### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,4 +1,6 @@
 name: Bandit Security Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/camcam1773/flask_CRUD/security/code-scanning/3](https://github.com/camcam1773/flask_CRUD/security/code-scanning/3)

To fix this issue, we need to add a `permissions` key (with the minimal permissions possible) either at the root of the workflow or at the job level. Since no job in the workflow requires write permissions (the steps only read the code and run a scan), the best practice is to set `contents: read` permissions at the root (or for the job, if the workflow is more complex). For this specific `bandit-check` job, setting `permissions: contents: read` directly under the job definition is sufficient; alternatively, placing it at the root covers all jobs, which is also preferred for simplicity and future-proofing. The required change is to add:

```yaml
permissions:
  contents: read
```

as line 2, shifting the rest of the workflow down by one line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
